### PR TITLE
Fixing Geo bots prefix issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,7 +148,7 @@ function isBotCommand(message) {
         // message must contain a parsable string
         typeof message.content === "string"
         // bot must be addressed directly
-        && message.content.startsWith("<@" + client.user.id + ">")
+        && (message.content.startsWith("<@" + client.user.id + ">") || message.content.startsWith("<@!" + client.user.id + ">"))
     )
 }
 


### PR DESCRIPTION
As it doesn't handle the situation if Geobot has a nickname

Geobot "RAW" mention without a nickname: <@536808091455324160>
Geobot "RAW" mention with a nickname: <@!536808091455324160>